### PR TITLE
Feature/gasless

### DIFF
--- a/ci/e2e-group1/gasless_test.go
+++ b/ci/e2e-group1/gasless_test.go
@@ -1,0 +1,1 @@
+../../test/e2e/gasless_test.go

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -59,6 +59,7 @@ func NewPool(cfg Config, s storage, st stateInterface, l2BridgeAddr common.Addre
 		state:                   st,
 		chainID:                 chainID,
 		blockedAddresses:        sync.Map{},
+		minSuggestedGasPrice:    big.NewInt(int64(cfg.DefaultMinGasPriceAllowed)),
 		minSuggestedGasPriceMux: new(sync.RWMutex),
 		eventLog:                eventLog,
 	}

--- a/test/config/debug.node.config.toml
+++ b/test/config/debug.node.config.toml
@@ -15,7 +15,6 @@ EnableLog = true
 MaxConns = 10
 
 [Pool]
-FreeClaimGasLimit = 1500000
 IntervalToRefreshBlockedAddresses = "5m"
 MaxTxBytesSize=30132
 MaxTxDataBytesSize=30000

--- a/test/config/test.node.config.toml
+++ b/test/config/test.node.config.toml
@@ -15,7 +15,6 @@ EnableLog = false
 MaxConns = 200
 
 [Pool]
-FreeClaimGasLimit = 1500000
 IntervalToRefreshBlockedAddresses = "5m"
 MaxTxBytesSize=100132
 MaxTxDataBytesSize=100000

--- a/test/e2e/gasless_test.go
+++ b/test/e2e/gasless_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"os/exec"
 	"testing"
@@ -23,26 +24,30 @@ func TestEthTransferGasless(t *testing.T) {
 		t.Skip()
 	}
 	// Edit config
+	out, err := exec.Command("pwd").CombinedOutput()
+	fmt.Println(string(out))
+	require.NoError(t, err)
+	const path = "../../test/config/test.node.config.toml"
 	require.NoError(t,
-		exec.Command("sed", "-i", "s/DefaultMinGasPriceAllowed = 1000000000/DefaultMinGasPriceAllowed = 0/g", "./config/test.node.config.toml").Run(),
+		exec.Command("sed", "-i", "s/DefaultMinGasPriceAllowed = 1000000000/DefaultMinGasPriceAllowed = 0/g", path).Run(),
 	)
 	require.NoError(t,
-		exec.Command("sed", "-i", "s/EnableL2SuggestedGasPricePolling = true/EnableL2SuggestedGasPricePolling = false/g", "./config/test.node.config.toml").Run(),
+		exec.Command("sed", "-i", "s/EnableL2SuggestedGasPricePolling = true/EnableL2SuggestedGasPricePolling = false/g", path).Run(),
 	)
 	// Undo edit config
 	defer func() {
 		require.NoError(t,
-			exec.Command("sed", "-i", "s/DefaultMinGasPriceAllowed = 0/DefaultMinGasPriceAllowed = 1000000000/g", "./config/test.node.config.toml").Run(),
+			exec.Command("sed", "-i", "s/DefaultMinGasPriceAllowed = 0/DefaultMinGasPriceAllowed = 1000000000/g", path).Run(),
 		)
 		require.NoError(t,
-			exec.Command("sed", "-i", "s/EnableL2SuggestedGasPricePolling = false/EnableL2SuggestedGasPricePolling = true/g", "./config/test.node.config.toml").Run(),
+			exec.Command("sed", "-i", "s/EnableL2SuggestedGasPricePolling = false/EnableL2SuggestedGasPricePolling = true/g", path).Run(),
 		)
 	}()
 
 	ctx := context.Background()
 	defer func() { require.NoError(t, operations.Teardown()) }()
 
-	err := operations.Teardown()
+	err = operations.Teardown()
 	require.NoError(t, err)
 	opsCfg := operations.GetDefaultOperationsConfig()
 	opsCfg.State.MaxCumulativeGasUsed = 80000000000

--- a/test/e2e/gasless_test.go
+++ b/test/e2e/gasless_test.go
@@ -1,0 +1,91 @@
+package e2e
+
+import (
+	"context"
+	"math/big"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/0xPolygon/supernets2-node/log"
+	"github.com/0xPolygon/supernets2-node/test/operations"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEthTransferGasless(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+	// Edit config
+	require.NoError(t,
+		exec.Command("sed", "-i", "s/DefaultMinGasPriceAllowed = 1000000000/DefaultMinGasPriceAllowed = 0/g", "./config/test.node.config.toml").Run(),
+	)
+	require.NoError(t,
+		exec.Command("sed", "-i", "s/EnableL2SuggestedGasPricePolling = true/EnableL2SuggestedGasPricePolling = false/g", "./config/test.node.config.toml").Run(),
+	)
+	// Undo edit config
+	defer func() {
+		require.NoError(t,
+			exec.Command("sed", "-i", "s/DefaultMinGasPriceAllowed = 0/DefaultMinGasPriceAllowed = 1000000000/g", "./config/test.node.config.toml").Run(),
+		)
+		require.NoError(t,
+			exec.Command("sed", "-i", "s/EnableL2SuggestedGasPricePolling = false/EnableL2SuggestedGasPricePolling = true/g", "./config/test.node.config.toml").Run(),
+		)
+	}()
+
+	ctx := context.Background()
+	defer func() { require.NoError(t, operations.Teardown()) }()
+
+	err := operations.Teardown()
+	require.NoError(t, err)
+	opsCfg := operations.GetDefaultOperationsConfig()
+	opsCfg.State.MaxCumulativeGasUsed = 80000000000
+	opsman, err := operations.NewManager(ctx, opsCfg)
+	require.NoError(t, err)
+	err = opsman.Setup()
+	require.NoError(t, err)
+	time.Sleep(5 * time.Second)
+	// Load account with balance on local genesis
+	pk, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	auth, err := bind.NewKeyedTransactorWithChainID(pk, big.NewInt(0).SetUint64(operations.DefaultL2ChainID))
+	require.NoError(t, err)
+	// Load eth client
+	client, err := ethclient.Dial(operations.DefaultL2NetworkURL)
+	require.NoError(t, err)
+	// Send txs
+	nTxs := 10
+	amount := big.NewInt(0)
+	toAddress := common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8")
+	senderBalance, err := client.BalanceAt(ctx, auth.From, nil)
+	require.NoError(t, err)
+	senderNonce, err := client.PendingNonceAt(ctx, auth.From)
+	require.NoError(t, err)
+
+	log.Infof("Receiver Addr: %v", toAddress.String())
+	log.Infof("Sender Addr: %v", auth.From.String())
+	log.Infof("Sender Balance: %v", senderBalance.String())
+	log.Infof("Sender Nonce: %v", senderNonce)
+
+	gasLimit, err := client.EstimateGas(ctx, ethereum.CallMsg{From: auth.From, To: &toAddress, Value: amount})
+	require.NoError(t, err)
+
+	gasPrice := big.NewInt(0)
+	nonce, err := client.PendingNonceAt(ctx, auth.From)
+	require.NoError(t, err)
+
+	txs := make([]*types.Transaction, 0, nTxs)
+	for i := 0; i < nTxs; i++ {
+		tx := types.NewTransaction(nonce+uint64(i), toAddress, amount, gasLimit, gasPrice, nil)
+		txs = append(txs, tx)
+	}
+
+	_, err = operations.ApplyL2Txs(ctx, txs, auth, client, operations.VerifiedConfirmationLevel)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
- prevent panic when gas price polling is disabled
- improve `ApplyL2Txs` so it works for non trusted sequencer in initial conditions setup
- add test to assert that gasless txs (gas price == 0) work