### PR TITLE
Fixed Port Number for explorer in docker-compose.yml in test Directory during local setup

### DIFF
--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -245,7 +245,7 @@ services:
     container_name: supernets2-explorer-l1-db
     image: postgres
     ports:
-      - 5435:5432
+      - 5436:5432
     environment:
       - POSTGRES_USER=l1_explorer_user
       - POSTGRES_PASSWORD=l1_explorer_password
@@ -299,7 +299,7 @@ services:
     container_name: supernets2-explorer-l2-db
     image: postgres
     ports:
-      - 5436:5432
+      - 5437:5432
     environment:
       - POSTGRES_USER=l2_explorer_user
       - POSTGRES_PASSWORD=l2_explorer_password


### PR DESCRIPTION
The current port configuration of supernets2-explorer-l1-db and supernets2-event-db clash. They have been assigned the same port 5435.

Updated the Port Assignment to the following:
-supernets2-explorer-l1-db : 5436
-supernets2-explorer-l2-db : 5437
-supernets2-event-db : 5435

Issue : https://github.com/0xPolygon/supernets2-node/issues/6