### PR TITLE
Update the test compose file to be in sync with the main one

### DIFF
--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -449,8 +449,8 @@ services:
       - "-c"
       - "/app/supernets2-node run --network custom --custom-network-file /app/genesis.json --cfg /app/config.toml --components \"rpc,synchronizer\""
 
-  supernets2-data-node-db:
-    container_name: supernets2-data-node-db
+  supernets2-data-availability-db:
+    container_name: supernets2-data-availability-db
     restart: unless-stopped
     image: postgres
     healthcheck:


### PR DESCRIPTION
To keep the two compose files (i.e. from and outside of the test folder) in sync

see https://github.com/0xPolygon/supernets2-node/commit/74587488f868015b800641f5a195372d26725239#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3

there is:

<img width="1190" alt="image" src="https://github.com/0xPolygon/supernets2-node/assets/111917526/808cd83b-d422-42b7-9fec-5b3321ccfabc">
